### PR TITLE
Update zfs_lab.ipynb

### DIFF
--- a/labs/zfs_lab.ipynb
+++ b/labs/zfs_lab.ipynb
@@ -167,7 +167,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Disks can get shuffled and sda or sdb can re-letter in the worst times so lets alter to disks by-id.  Investigate the differences in the zpool status output from above."
+    "## Disks can get shuffled and sda or sdb can re-letter in the worst times so lets alter to disks by-path.  Investigate the differences in the zpool status output from above."
    ]
   },
   {
@@ -176,7 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "zpool export tank && zpool import tank -d /dev/disk/by-id && zpool status"
+    "zpool export tank && zpool import tank -d /dev/disk/by-path && zpool status"
    ]
   },
   {
@@ -210,7 +210,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "zpool destroy tank && zpool create tank -f sda sdb && zpool export tank && zpool import tank -d /dev/disk/by-id && zpool status"
+    "zpool destroy tank && zpool create tank -f sda sdb && zpool export tank && zpool import tank -d /dev/disk/by-path && zpool status"
    ]
   },
   {


### PR DESCRIPTION
replace `disk/by-id` with `disk/by-path`. 

this fixes the issue with udev assigning the same device ID to 2 nearly identical USB sticks and thus creating only 1 symlink for 2 devices.